### PR TITLE
Add GCDWebServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ to be accessed and controlled from a single terminal.
 - [Lantern](https://github.com/getlantern/lantern) Lantern delivers fast access to the open Internet （翻墙）
 - [wireshark](https://www.wireshark.org/) Wireshark is the world’s foremost and widely-used network protocol analyzer. It lets you see what’s happening on your network at a microscopic level and is the de facto (and often de jure) standard across many commercial and non-profit enterprises, government agencies, and educational institutions.
 - [netfox](https://github.com/kasketis/netfox) A lightweight, one line setup, iOS / OSX network debugging library! 🦊
+- [GCDWebServer](https://github.com/swisspol/GCDWebServer) GCDWebServer is a modern and lightweight GCD based HTTP 1.1 server designed to be embedded in iOS, macOS & tvOS apps.
 
 ## Data
 - [sqlitebrowser](http://sqlitebrowser.org/) DB Browser for SQLite


### PR DESCRIPTION
GCDWebServer主要使用在app端产生服务器，供连接查看或修改app内部内容。