### PR TITLE
Add SkrybaMD documentation generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,3 +313,4 @@ to be accessed and controlled from a single terminal.
 - [PushMate](https://pushmate.app) PushMate is a MacOS app that solves common push notification problems by ensuring your push payloads are correct.
 - [emojipedia](https://emojipedia.org) Wiki of emoji
 - [XcodeCleaner](https://github.com/waylybaye/XcodeCleaner) Cleaner for Xcode.app built with react-native-macos
+- [SkrybaMD](https://github.com/robertherdzik/SkrybaMD) - Markdown Documentation generator. If your team need easy way to maintain and create documentation, this generator is for you.


### PR DESCRIPTION
I have added SkrybaMD Markdown Documentation generator Tool

## Project URL
https://github.com/robertherdzik/SkrybaMD

Tool is very useful once your team and project starts to grow. In easy give you possibility to maintain Documentation and is less error prone than manual changing the numeration of the subject and indentation. You simply have one patter source file and base on this output is generated automatically.


## Checklist
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English