### PR TITLE
DronaHQ_listing_in_platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@
 	- [Crashlytics](https://firebase.google.com/docs/crashlytics/) Spend less time troubleshooting & more time building great apps. 
 - [Parse](https://parseplatform.org/) Build applications faster with object and file storage,
 user authentication, push notifications, dashboard and more out of the box.
-
+- [DronaHQ] (https://www.dronahq.com/) Build custom apps, dashboards, internal tools at 10x speed without coding and roll out quickly on iOS.
 
 ## Command Line Tool
 


### PR DESCRIPTION
Adding DronaHQ in Platforms, DronaHQ helps developers build custom apps, internal tools, dashboards at 10x speed, which can be rolled out on iOS rapidly.